### PR TITLE
only send format editings when necessary

### DIFF
--- a/src/DocumentStore.zig
+++ b/src/DocumentStore.zig
@@ -147,6 +147,7 @@ fn loadPackages(context: LoadPackagesContext) !void {
             context.cache_root,
             context.global_cache_root,
         },
+        .max_output_bytes = 50 * 1024 * 1024,
     });
 
     defer {


### PR DESCRIPTION
If the original document is same as the formatted one, there's no need to send the unchanged
document's content back which will make the client confused.

Signed-off-by: Tw <wei.tan@intel.com>